### PR TITLE
Add jest and supertest with example test

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -33,7 +33,13 @@ app.get('/api/tree', (req, res) => {
     });
 });
 
-const PORT = 3001;
-app.listen(PORT, () => {
-    console.log(`Server running on http://localhost:${PORT}`);
-});
+// Export the app for testing
+module.exports = app;
+
+// Start the server when this file is run directly
+if (require.main === module) {
+    const PORT = 3001;
+    app.listen(PORT, () => {
+        console.log(`Server running on http://localhost:${PORT}`);
+    });
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -13,5 +13,9 @@
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /api/tree', () => {
+  it('responds with array', async () => {
+    const res = await request(app).get('/api/tree');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- export app from `index.js`
- add Jest and Supertest as dev dependencies
- add initial API test using Supertest
- run tests with `npm test`

## Testing
- `npm test` *(fails: jest not found)*