### PR TITLE
Add highcharts dependency

### DIFF
--- a/frontend/nuxt-highcharts-treemap/package.json
+++ b/frontend/nuxt-highcharts-treemap/package.json
@@ -13,6 +13,7 @@
     "nuxt": "^3.16.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
-    "axios": "^1.6.8"
+    "axios": "^1.6.8",
+    "highcharts": "^x.y.z"
   }
 }


### PR DESCRIPTION
## Summary
- add `highcharts` placeholder dependency in treemap app

## Testing
- `yarn install` *(fails: highcharts@^x.y.z isn't supported)*
- `npm install` *(fails due to network restrictions)*