### PR TITLE
Fix highcharts treemap SSR error

### DIFF
--- a/frontend/nuxt-highcharts-treemap/pages/index.vue
+++ b/frontend/nuxt-highcharts-treemap/pages/index.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <h1>Highcharts Treemap</h1>
-    <TreeMapChart />
+    <ClientOnly>
+      <TreeMapChart />
+    </ClientOnly>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- only render `TreeMapChart` component on the client to prevent server-side error

## Testing
- `npm test --prefix backend` *(fails: jest not found)*