### PR TITLE
Add extra backend tests

### DIFF
--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -7,4 +7,26 @@ describe('GET /api/tree', () => {
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
   });
+
+  it('includes root node with null parent', async () => {
+    const res = await request(app).get('/api/tree');
+    expect(res.statusCode).toBe(200);
+    const root = res.body.find(item => item.name === 'Root');
+    expect(root).toBeDefined();
+    expect(root.parent_id).toBeNull();
+  });
+
+  it('returns the expected number of entries', async () => {
+    const res = await request(app).get('/api/tree');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(101);
+  });
+});
+
+describe('Unknown routes', () => {
+  it('responds with 404 for non-existent route', async () => {
+    const res = await request(app).get('/not-found');
+    expect(res.statusCode).toBe(404);
+  });
 });


### PR DESCRIPTION
## Summary
- increase coverage of API with additional Jest tests
- consolidate backend tests into a single file

## Testing
- `npm test --silent --prefix backend` *(fails: jest not found)*