### PR TITLE
Make backend API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ This repository contains a simple backend API using Express and SQLite and a Nux
    ```
    The application will be available at `http://localhost:3000` and fetch data from the backend API.
 
+### Environment Variables
+
+The frontend reads the backend URL from the `API_URL` environment variable using Nuxt runtime configuration. If not provided, it defaults to `http://localhost:3001`.
+Set `API_URL` if your backend runs on a different host or port.
+

--- a/frontend/nuxt-highcharts-treemap/components/TreeMapChart.vue
+++ b/frontend/nuxt-highcharts-treemap/components/TreeMapChart.vue
@@ -8,6 +8,8 @@ import Highcharts from "highcharts";
 import treemap from "highcharts/modules/treemap";
 import axios from "axios";
 
+const { public: { apiUrl } } = useRuntimeConfig();
+
 treemap(Highcharts);
 
 const chartContainer = ref(null);
@@ -16,7 +18,7 @@ const chartData = ref([]);
 
 async function fetchData() {
   try {
-    const response = await axios.get("http://localhost:3001/api/tree"); // Update the URL if your backend runs elsewhere
+    const response = await axios.get(`${apiUrl}/api/tree`);
     chartData.value = response.data;
   } catch (error) {
     console.error("Error fetching data:", error);

--- a/frontend/nuxt-highcharts-treemap/nuxt.config.ts
+++ b/frontend/nuxt-highcharts-treemap/nuxt.config.ts
@@ -1,5 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  runtimeConfig: {
+    public: {
+      apiUrl: process.env.API_URL || 'http://localhost:3001'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- enable runtime API URL config for treemap chart
- expose `apiUrl` in `nuxt.config.ts`
- document `API_URL` environment variable in README

## Testing
- `npm run build` *(fails: nuxt not found)*